### PR TITLE
fix: update configuration example to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Open up your Eleventy config file (probably `.eleventy.js`) and use `addPlugin`:
 
 ```
 const inclusiveLangPlugin = require("@11ty/eleventy-plugin-inclusive-language");
+
 module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(inclusiveLangPlugin);
 };
@@ -28,13 +29,16 @@ Read more about [Eleventy plugins.](https://www.11ty.io/docs/plugins/)
 Optionally pass in an options object as the second argument to `addPlugin` to further customize this plugin.
 
 ```
-const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
+const inclusiveLangPlugin = require("@11ty/eleventy-plugin-inclusive-language");
+
 module.exports = function(eleventyConfig) {
-  eleventyConfig.addPlugin(syntaxHighlight, {
+  eleventyConfig.addPlugin(inclusiveLangPlugin, {
     templateFormats: ["md"], // default, add more file extensions here
 
     // accepts an array or a comma-delimited string
-    words: "simply,obviously,basically,of course,clearly,just,everyone knows,however,easy"
+    words:
+      "simply,obviously,basically,of course,clearly,just,everyone knows,however,easy"
   });
 };
+
 ```


### PR DESCRIPTION
- Update configuration example to the documentation
- Improve readability of the code snippets with extra white-space
- Making sure that people can use custom options of the plugin